### PR TITLE
Printing help bug is fixed.

### DIFF
--- a/core/src/main/java/org/apache/sdap/mudrod/main/MudrodEngine.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/main/MudrodEngine.java
@@ -391,7 +391,7 @@ public class MudrodEngine {
       me.end();
     } catch (Exception e) {
       HelpFormatter formatter = new HelpFormatter();
-      formatter.printHelp("MudrodEngine: 'dataDir' argument is mandatory. " + "User must also provide an ingest method.", true);
+      formatter.printHelp("MudrodEngine: 'dataDir' argument is mandatory. " + "User must also provide an ingest method.", new Options());
       LOG.error("Error whilst parsing command line.", e);
     }
   }


### PR DESCRIPTION
SDAP-165 Fixes MUDROD bugs to get master branch running(#34) with stop printing cli options in middle of exception but it breaks the code to compile. An empty Options() object is added to achieve the same purpose.