### PR TITLE
SDAP-198 InterruptedExceptions are handled.

### DIFF
--- a/core/src/main/java/org/apache/sdap/mudrod/driver/ESDriver.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/driver/ESDriver.java
@@ -244,6 +244,9 @@ public class ESDriver implements Serializable {
       }
     } catch (InterruptedException | ExecutionException e) {
       LOG.error("Error whilst obtaining type list from Elasticsearch mappings.", e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
     }
     return typeList;
   }

--- a/core/src/main/java/org/apache/sdap/mudrod/integration/LinkageIntegration.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/integration/LinkageIntegration.java
@@ -106,6 +106,9 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
       map = aggregateRelatedTermsFromAllmodel(es.customAnalyzing(props.getProperty(INDEX_NAME), input));
     } catch (InterruptedException | ExecutionException e) {
       LOG.error("Error applying majority rule", e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
     }
 
     for (Entry<String, List<LinkedTerm>> entry : map.entrySet()) {

--- a/core/src/main/java/org/apache/sdap/mudrod/tools/EONETIngester.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/tools/EONETIngester.java
@@ -134,6 +134,9 @@ public class EONETIngester extends MudrodAbstract {
         updateResponse = esDriver.getClient().update(updateRequest).get();
       } catch (InterruptedException | ExecutionException e) {
         LOG.error("Failed to execute bulk Index request : ", e);
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
       }
       if (updateResponse != null) {
         result = updateResponse.getGetResult();

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/pre/CrawlerDetection.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/pre/CrawlerDetection.java
@@ -86,6 +86,9 @@ public class CrawlerDetection extends LogAbstract {
       checkByRateInParallel();
     } catch (InterruptedException | IOException e) {
       LOG.error("Encountered an error whilst detecting Web crawlers.", e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
     }
     endTime = System.currentTimeMillis();
     es.refreshIndex();

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/session/SessionTree.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/session/SessionTree.java
@@ -209,6 +209,9 @@ public class SessionTree extends MudrodAbstract {
         viewquery = es.customAnalyzing(props.getProperty(MudrodConstants.ES_INDEX_NAME), infoStr);
       } catch (UnsupportedEncodingException | InterruptedException | ExecutionException e) {
         LOG.warn("Exception getting search info. Ignoring...", e);
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
       }
 
       String dataset = viewnode.getDatasetId();
@@ -491,6 +494,9 @@ public class SessionTree extends MudrodAbstract {
         try {
           query = es.customAnalyzing(props.getProperty(MudrodConstants.ES_INDEX_NAME), infoStr);
         } catch (InterruptedException | ExecutionException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           throw new RuntimeException("Error performing custom analyzing", e);
         }
         Map<String, String> filter = RequestUrl.getFilterInfo(queryUrl);

--- a/service/src/main/java/org/apache/sdap/mudrod/services/search/SearchDatasetDetailResource.java
+++ b/service/src/main/java/org/apache/sdap/mudrod/services/search/SearchDatasetDetailResource.java
@@ -68,6 +68,9 @@ public class SearchDatasetDetailResource {
       dataDetailJson = mEngine.getESDriver().searchByQuery(config.getProperty(MudrodConstants.ES_INDEX_NAME), config.getProperty(MudrodConstants.RAW_METADATA_TYPE), query, true);
     } catch (InterruptedException | ExecutionException | IOException e) {
       LOG.error("Error whilst searching for a Dataset-ShortName: ", e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
     }
     LOG.info("Response received: {}", dataDetailJson);
     return Response.ok(dataDetailJson, MediaType.APPLICATION_JSON).build();


### PR DESCRIPTION
InterruptedExceptions should never be ignored in the code. Just logging the exception or throwing another one clears the interrupted state of the Thread.